### PR TITLE
[PKG-2490] rdkit 2023.03.2 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sfe1ed40
-channels:
-  - sfe1ed40
-upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sfe1ed40
+channels:
+  - sfe1ed40
+upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-aggregate_check: false
-upload_channels:
-  - sfe1ed40
-channels:
-  - sfe1ed40

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,22 +1,10 @@
-:: cmd
-echo "Building %PKG_NAME%."
-
-
-:: Isolate the build.
-mkdir Build-%PKG_NAME%
-cd Build-%PKG_NAME%
-if errorlevel 1 exit /b 1
-
 REM Change Python header location.
 xcopy %LIBRARY_INC%\boost\python\python.hpp %LIBRARY_INC%\boost
 
-:: Generate the build files.
-echo "Generating the build files..."
-cmake .. %CMAKE_ARGS% ^
-    -G"Ninja" ^
-    -D CMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
-    -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+cmake ^
+    -G "NMake Makefiles JOM" ^
     -D CMAKE_BUILD_TYPE=Release ^
+    -D CMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
     -D BOOST_ROOT="%LIBRARY_PREFIX%" ^
     -D Boost_NO_SYSTEM_PATHS=ON ^
     -D Boost_NO_BOOST_CMAKE=ON ^
@@ -34,19 +22,14 @@ cmake .. %CMAKE_ARGS% ^
     -D RDK_INSTALL_DLLS_MSVC=ON ^
     -D RDK_INSTALL_DEV_COMPONENT=OFF ^
     -D RDK_INSTALL_INTREE=OFF ^
+    .
 if errorlevel 1 exit 1
 
+cmake --build . --config Release
+if errorlevel 1 exit 1
 
-:: Build.
-echo "Building..."
-ninja -j%CPU_COUNT%
-if errorlevel 1 exit /b 1
-
-
-:: Install.
-echo "Installing..."
-ninja install
-if errorlevel 1 exit /b 1
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1
 
 REM copy .dll files to LIBRARY_BIN
 copy bin\*.dll %LIBRARY_BIN%
@@ -62,8 +45,3 @@ xcopy /y External\FreeSASA\*.h %LIBRARY_INC%\rdkit\GraphMol
 xcopy /y External\CoordGen\*.h %LIBRARY_INC%\rdkit\GraphMol
 xcopy /y External\YAeHMOP\*.h %LIBRARY_INC%\rdkit\GraphMol
 xcopy /y External\RingFamilies\RingDecomposerLib\src\RingDecomposerLib\RingDecomposerLib.h %LIBRARY_INC%\rdkit
-
-
-:: Error free exit.
-echo "Error free exit!"
-exit 0

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,10 +1,22 @@
+:: cmd
+echo "Building %PKG_NAME%."
+
+
+:: Isolate the build.
+mkdir Build-%PKG_NAME%
+cd Build-%PKG_NAME%
+if errorlevel 1 exit /b 1
+
 REM Change Python header location.
 xcopy %LIBRARY_INC%\boost\python\python.hpp %LIBRARY_INC%\boost
 
-cmake ^
-    -G "NMake Makefiles JOM" ^
+:: Generate the build files.
+echo "Generating the build files..."
+cmake .. %CMAKE_ARGS% ^
+    -G"Ninja" ^
+    -D CMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
+    -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
     -D CMAKE_BUILD_TYPE=Release ^
-    -D CMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
     -D BOOST_ROOT="%LIBRARY_PREFIX%" ^
     -D Boost_NO_SYSTEM_PATHS=ON ^
     -D Boost_NO_BOOST_CMAKE=ON ^
@@ -22,14 +34,19 @@ cmake ^
     -D RDK_INSTALL_DLLS_MSVC=ON ^
     -D RDK_INSTALL_DEV_COMPONENT=OFF ^
     -D RDK_INSTALL_INTREE=OFF ^
-    .
 if errorlevel 1 exit 1
 
-cmake --build . --config Release
-if errorlevel 1 exit 1
 
-cmake --build . --config Release --target install
-if errorlevel 1 exit 1
+:: Build.
+echo "Building..."
+ninja -j%CPU_COUNT%
+if errorlevel 1 exit /b 1
+
+
+:: Install.
+echo "Installing..."
+ninja install
+if errorlevel 1 exit /b 1
 
 REM copy .dll files to LIBRARY_BIN
 copy bin\*.dll %LIBRARY_BIN%
@@ -45,3 +62,8 @@ xcopy /y External\FreeSASA\*.h %LIBRARY_INC%\rdkit\GraphMol
 xcopy /y External\CoordGen\*.h %LIBRARY_INC%\rdkit\GraphMol
 xcopy /y External\YAeHMOP\*.h %LIBRARY_INC%\rdkit\GraphMol
 xcopy /y External\RingFamilies\RingDecomposerLib\src\RingDecomposerLib\RingDecomposerLib.h %LIBRARY_INC%\rdkit
+
+
+:: Error free exit.
+echo "Error free exit!"
+exit 0

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,6 +2,13 @@
 
 set -euxo pipefail
 
+echo "Building ${PKG_NAME}."
+
+
+# Isolate the build.
+mkdir -p Build-${PKG_NAME}
+cd Build-${PKG_NAME} || exit 1
+
 POPCNT_OPTIMIZATION="ON"
 if [[ "$target_platform" == linux-ppc64le || "$target_platform" == linux-aarch64 ]]; then
     # PowerPC includes -mcpu=power8 optimizations already
@@ -15,33 +22,48 @@ if [[ "$target_platform" == linux-ppc64le ]]; then
     EXTRA_CMAKE_FLAGS+=" -D PYTHON_NUMPY_INCLUDE_PATH=${SP_DIR}/numpy/core/include"
 fi
 
-cmake ${CMAKE_ARGS} \
-    -D CMAKE_BUILD_TYPE=Release \
-    -D CMAKE_INSTALL_PREFIX="$PREFIX" \
-    -D BOOST_ROOT="$PREFIX" \
-    -D Boost_NO_SYSTEM_PATHS=ON \
-    -D Boost_NO_BOOST_CMAKE=ON \
-    -D PYTHON_EXECUTABLE="$PYTHON" \
-    -D PYTHON_INSTDIR="$SP_DIR" \
-    -D RDK_BUILD_AVALON_SUPPORT=ON \
-    -D RDK_BUILD_CAIRO_SUPPORT=ON \
-    -D RDK_BUILD_CPP_TESTS=OFF \
-    -D RDK_BUILD_INCHI_SUPPORT=ON \
-    -D RDK_BUILD_FREESASA_SUPPORT=ON \
-    -D RDK_BUILD_YAEHMOP_SUPPORT=ON \
-    -D RDK_BUILD_XYZ2MOL_SUPPORT=ON \
-    -D RDK_BUILD_PYTHON_WRAPPERS=ON \
-    -D RDK_INSTALL_INTREE=OFF \
-    -D RDK_INSTALL_STATIC_LIBS=OFF \
-    -D RDK_OPTIMIZE_POPCNT=${POPCNT_OPTIMIZATION} \
-    ${EXTRA_CMAKE_FLAGS} \
-    .
+# Generate the build files.
+echo "Generating the build files..."
 
-make -j$CPU_COUNT
-make install
+cmake .. ${CMAKE_ARGS} \
+-GNinja \
+-D CMAKE_PREFIX_PATH=${PREFIX} \
+-D CMAKE_INSTALL_PREFIX=${PREFIX} \
+-D CMAKE_BUILD_TYPE=Release \
+-D BOOST_ROOT="$PREFIX" \
+-D Boost_NO_SYSTEM_PATHS=ON \
+-D Boost_NO_BOOST_CMAKE=ON \
+-D PYTHON_EXECUTABLE="$PYTHON" \
+-D PYTHON_INSTDIR="$SP_DIR" \
+-D RDK_BUILD_AVALON_SUPPORT=ON \
+-D RDK_BUILD_CAIRO_SUPPORT=ON \
+-D RDK_BUILD_CPP_TESTS=OFF \
+-D RDK_BUILD_INCHI_SUPPORT=ON \
+-D RDK_BUILD_FREESASA_SUPPORT=ON \
+-D RDK_BUILD_YAEHMOP_SUPPORT=ON \
+-D RDK_BUILD_XYZ2MOL_SUPPORT=ON \
+-D RDK_BUILD_PYTHON_WRAPPERS=ON \
+-D RDK_INSTALL_INTREE=OFF \
+-D RDK_INSTALL_STATIC_LIBS=OFF \
+-D RDK_OPTIMIZE_POPCNT=${POPCNT_OPTIMIZATION} \
+${EXTRA_CMAKE_FLAGS}
+
+
+# Build.
+echo "Building..."
+ninja -j${CPU_COUNT} || exit 1
 
 ## How to run unit tests:
 ## 1. Set RDK_BUILD_CPP_TESTS to ON
 ## 2. Uncomment lines below
 # export RDBASE="$SRC_DIR"
 # ctest --output-on-failure
+
+# Installing
+echo "Installing..."
+ninja install || exit 1
+
+
+# Error free exit!
+echo "Error free exit!"
+exit 0

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,2 @@
+MACOSX_SDK_VERSION:        # [osx and x86_64]
+  - "10.13"                # [osx and x86_64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,8 @@
-MACOSX_SDK_VERSION:        # [osx and x86_64]
-  - "10.13"                # [osx and x86_64]
+macos_min_version:
+  - 10.15  # [osx and x86_64]
+MACOSX_DEPLOYMENT_TARGET:
+  - 10.15  # [osx and x86_64]
+MACOSX_SDK_VERSION:
+  - "10.15"                # [osx and x86_64]
+CONDA_BUILD_SYSROOT:
+  - /opt/MacOSX10.15.sdk        # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,22 +32,22 @@ requirements:
     - ninja
     - pkg-config
   host:
-    - boost-cpp 1.73.0                             # [win]
+    - boost-cpp                            # [win]
     - cairo
-    - eigen 3.3.7
+    - eigen
     - freetype
-    - libboost 1.73.0
+    - libboost
     - numpy
     - pandas
     - pillow
-    - py-boost 1.73.0
+    - py-boost
     - python
     - setuptools
     - wheel
   run:
     - {{ pin_compatible('numpy') }}
-    - cairo >=1.16.0,<2.0a0
-    - libboost >=1.73.0,<1.73.1.0a0
+    - cairo
+    - libboost
     - matplotlib-base
     - pandas
     - pillow

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,14 +8,15 @@ package:
 
 source:
   fn: {{ filename }}
-  url: https://github.com/rdkit/rdkit/archive/{{ filename }}
+  url: https://github.com/{{ name }}/{{ name }}/archive/{{ filename }}
   sha256: bb43216b075b93b767e6cbaecd5e95d087da887bcdc51afd36d940d8bd9f9819
 
 build:
   number: 0
   # We skip s390x because it's not supported.
   skip: True # [s390x]
-  skip: True # [py<37]
+  # py-boost hasn't been built for Python 3.11 yet.
+  skip: True # [py<37 or py>310]
   missing_dso_whitelist:
     - '*/RDKit*dll'  # [win]
   run_exports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,35 +27,37 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
+    - python
     - numpy
     - cmake
-    - ninja
+    - jom                                    # [win]
+    - make                                   # [unix]
     - pkg-config
   host:
-    - boost-cpp                            # [win]
+    - boost-cpp                              # [win]
+    - libboost
+    - py-boost
     - cairo
     - eigen
     - freetype
-    - libboost
-    - numpy
-    - pandas
-    - pillow
-    - py-boost
     - python
+    - numpy
+    - pillow
+    - pandas
     - setuptools
     - wheel
   run:
-    - {{ pin_compatible('numpy') }}
-    - cairo
     - libboost
-    - matplotlib-base
-    - pandas
-    - pillow
     - py-boost
-    - pycairo
+    - cairo
     - python
-    - reportlab
+    - pillow
+    - pandas
+    - {{ pin_compatible('numpy') }}
+    - pycairo
+    - matplotlib-base
     - sqlalchemy
+    - reportlab
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rdkit" %}
-{% set version = "2022.09.4" %}
+{% set version = "2023.03.2" %}
 {% set filename = "Release_%s.tar.gz" % version.replace(".", "_") %}
 
 package:
@@ -9,7 +9,7 @@ package:
 source:
   fn: {{ filename }}
   url: https://github.com/rdkit/rdkit/archive/{{ filename }}
-  sha256: edd30682cc3031cf3f2b1a400f453629db332a1018f355cd3f7ff76b2f7f5398
+  sha256: bb43216b075b93b767e6cbaecd5e95d087da887bcdc51afd36d940d8bd9f9819
 
 build:
   number: 0
@@ -27,35 +27,35 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - python
     - numpy
     - cmake
-    - jom                                    # [win]
-    - make                                   # [unix]
+    - ninja
     - pkg-config
   host:
-    - boost-cpp                              # [win]
-    - libboost
-    - py-boost
+    - boost-cpp 1.73.0                             # [win]
     - cairo
-    - eigen
+    - eigen 3.3.7
     - freetype
-    - python
+    - libboost 1.73.0
     - numpy
-    - pillow
     - pandas
+    - pillow
+    - py-boost 1.73.0
+    - python
+    - setuptools
+    - wheel
   run:
-    - libboost
-    - py-boost
-    - cairo
-    - python
-    - pillow
-    - pandas
-    - numpy
-    - pycairo
+    - {{ pin_compatible('numpy') }}
+    - cairo >=1.16.0,<2.0a0
+    - libboost >=1.73.0,<1.73.1.0a0
     - matplotlib-base
-    - sqlalchemy
+    - pandas
+    - pillow
+    - py-boost
+    - pycairo
+    - python
     - reportlab
+    - sqlalchemy
 
 test:
   commands:


### PR DESCRIPTION
Changelog: https://github.com/rdkit/rdkit/releases
License: https://github.com/rdkit/rdkit/blob/master/license.txt
Requirements: 
- https://github.com/rdkit/rdkit/blob/master/Docs/Book/Install.md
- https://www.rdkit.org/docs/Install.html#how-to-build-from-source-with-conda
- https://github.com/rdkit/rdkit/blob/Release_2023_03_2/CMakeLists.txt

Actions:
1. Clean up the recipe:
- Add missing `setuptools` & `wheel` to `host`
2. Skip py>310 because `py-boost` hasn't been built for Python 3.11 yet. At the same time, **boost 1.82.0** is waiting for review https://github.com/AnacondaRecipes/boost-feedstock/pull/14 and will enable py311 support.
3. Replace numpy with {{ pin_compatible('numpy') }} in run as we use numpy in host
4. Add `MACOS_SDK_VERSION 10.15` to cbc.yaml. I tried `10.13` (see a related [issue](https://github.com/NixOS/nixpkgs/issues/90273)) but then `osx-64` failed so I updated to **10.15**.