### PR TITLE
[PKG-4128] 2023.09.1

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -47,4 +47,4 @@ make install
 ## 1. Set RDK_BUILD_CPP_TESTS to ON
 ## 2. Uncomment lines below
 export RDBASE="$SRC_DIR"
-ctest --output-on-failure -E "testConrec|pythonTestDirDbase|pythonTestDirChem"
+ctest --output-on-failure -E "testConrec|pythonTestDirDbase|pythonTestDirChem|pythonTestDirML"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -28,7 +28,7 @@ cmake ${CMAKE_ARGS} \
 -D PYTHON_INSTDIR="$SP_DIR" \
 -D RDK_BUILD_AVALON_SUPPORT=ON \
 -D RDK_BUILD_CAIRO_SUPPORT=OFF \
--D RDK_BUILD_CPP_TESTS=OFF \
+-D RDK_BUILD_CPP_TESTS=ON \
 -D RDK_BUILD_INCHI_SUPPORT=ON \
 -D RDK_BUILD_FREESASA_SUPPORT=ON \
 -D RDK_BUILD_YAEHMOP_SUPPORT=ON \
@@ -46,5 +46,5 @@ make install
 ## How to run unit tests:
 ## 1. Set RDK_BUILD_CPP_TESTS to ON
 ## 2. Uncomment lines below
-# export RDBASE="$SRC_DIR"
-# ctest --output-on-failure
+export RDBASE="$SRC_DIR"
+ctest --output-on-failure -E "testConrec|pythonTestDirDbase|pythonTestDirChem"

--- a/recipe/fix-install_comic_fonts.patch
+++ b/recipe/fix-install_comic_fonts.patch
@@ -1,0 +1,28 @@
+diff --git a/Code/GraphMol/MolDraw2D/CMakeLists.txt b/Code/GraphMol/MolDraw2D/CMakeLists.txt
+index b499bfe..58a8a3e 100644
+--- a/Code/GraphMol/MolDraw2D/CMakeLists.txt
++++ b/Code/GraphMol/MolDraw2D/CMakeLists.txt
+@@ -17,14 +17,16 @@ if (RDK_BUILD_FREETYPE_SUPPORT AND RDK_INSTALL_COMIC_FONTS)
+         set(needDownload "FALSE")
+     endif ()
+     if (needDownload)
+-        set(MD5Sum "850b0df852f1cda4970887b540f8f333")
+-        downloadAndCheckMD5("https://fonts.google.com/download?family=Comic%20Neue"
+-                "${CMAKE_CURRENT_SOURCE_DIR}/Comic_Neue.zip"
+-                ${MD5Sum})
+-        execute_process(COMMAND ${CMAKE_COMMAND} -E tar x
+-                ${CMAKE_CURRENT_SOURCE_DIR}/Comic_Neue.zip --format=zip
+-                WORKING_DIRECTORY ${RDKit_DataDir}/Fonts)
++        # we started having problems with constantly changing MD5s on the zip file,
++        # so now we just check the MD5 of the target file
++        downloadAndCheckMD5("https://github.com/google/fonts/raw/main/ofl/comicneue/ComicNeue-Regular.ttf"
++                "${RDKit_DataDir}/Fonts/ComicNeue-Regular.ttf"
++                "fc1eac54b325542d4c133732658f823b")
++        downloadAndCheckMD5("https://github.com/google/fonts/raw/main/ofl/comicneue/OFL.txt"
++                "${RDKit_DataDir}/Fonts/OFL.txt"
++                "")
+     endif (needDownload)
++
+ endif ()
+ 
+ rdkit_headers(MolDraw2D.h

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,10 @@ package:
 source:
   url: https://github.com/{{ name }}/{{ name }}/archive/{{ filename }}
   sha256: e0ff8e330c98b93ac8277a59b2369d9a38027afadb4f03bb34c6924d445f08d5
-
+  # Fixes outdated checksum for downloaded fonts.
+  patches:
+    - fix-install_comic_fonts.patch
+    
 build:
   number: 0
   # We skip s390x because it's not supported.
@@ -19,6 +22,8 @@ build:
 
 requirements:
   build:
+    - patch  # [not win]
+    - m2-patch  # [win]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,10 @@ source:
   url: https://github.com/{{ name }}/{{ name }}/archive/{{ filename }}
   sha256: e0ff8e330c98b93ac8277a59b2369d9a38027afadb4f03bb34c6924d445f08d5
   # Fixes outdated checksum for downloaded fonts.
+  # https://github.com/rdkit/rdkit/commit/ba0b6f3bafb391c17d7da9783f09817a4ba0f8f1
   patches:
     - fix-install_comic_fonts.patch
-    
+
 build:
   number: 0
   # We skip s390x because it's not supported.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rdkit" %}
-{% set version = "2023.03.3" %}
+{% set version = "2023.09.1" %}
 {% set filename = "Release_%s.tar.gz" % version.replace(".", "_") %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}/archive/{{ filename }}
-  sha256: bdbf9a2e6988526bfeb8c56ce3cdfe2998d60ac289078e2215374288185e8c8d
+  sha256: e0ff8e330c98b93ac8277a59b2369d9a38027afadb4f03bb34c6924d445f08d5
 
 build:
   number: 0


### PR DESCRIPTION
rdkit 2023.09.1 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4128]
- [Upstream repository](https://github.com/rdkit/rdkit/tree/Release_2023_09_1)
- [Upstream changelog/diff](https://github.com/rdkit/rdkit/releases/tag/Release_2023_09_1)

### Explanation of changes:

- Patched checksum issue with comic font download in build process.
- Attempted enabling upstream unit tests, but I'm not aware of a way to skip failing tests. More details in my comment below.
- The `invalid_url` errors in the linter are false positives.

[PKG-4128]: https://anaconda.atlassian.net/browse/PKG-4128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ